### PR TITLE
build.sh: fix setting of service_name variable

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@
 
 pushd $(dirname ${BASH_SOURCE[0]})
 export SERVICE=$(basename $PWD)
-export SERVICE_NAME=$(egrep -o "[^_]+$" <<<"$SERVICE_NAME")
+export SERVICE_NAME=$(egrep -o "[^_]+$" <<<"$SERVICE")
 export SERVICE_VERSION=$(git describe --tags)
 
 # docker does not allow to import files from external directories, so we


### PR DESCRIPTION
This is a bit of a cosmetics fix because $SERVICE_NAME is not really used
by Dockerfile. Another fix approach could be to remove the SERVICE_NAME
from build.sh and the Dockerfile all together.

PS. This issue is present in build.sh of all microflack micro services:
- microflack_ui (this repo)
- microflack_users
- microflack_socketio
- microflack_tokens
- microflack_messages